### PR TITLE
Fix closedness check in meth_getpeerverification

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -577,7 +577,7 @@ static int meth_getpeerverification(lua_State *L)
 {
   long err;
   p_ssl ssl = (p_ssl)luaL_checkudata(L, 1, "SSL:Connection");
-  if (ssl->state != LSEC_STATE_CONNECTED) {
+  if (ssl->state == LSEC_STATE_CLOSED) {
     lua_pushboolean(L, 0);
     lua_pushstring(L, "closed");
     return 2;


### PR DESCRIPTION
*Note: I'm PRing against a new master-0.7 branch, forked from the luasec-0.7 release, since we're not willing to update to 0.8 at this time.*

---

It's perfectly appropriate to get the verification state without the
connection having succeeded. That's the only way of finding out about
verification errors that prevented the connection from going through!